### PR TITLE
Add the SIGLIP embedding class and tests

### DIFF
--- a/llm_clip.py
+++ b/llm_clip.py
@@ -9,6 +9,7 @@ import io
 @llm.hookimpl
 def register_embedding_models(register):
     register(ClipEmbeddingModel())
+    register(SigLIPEmbeddingModel())
 
 
 class ClipEmbeddingModel(llm.EmbeddingModel):

--- a/llm_clip.py
+++ b/llm_clip.py
@@ -1,6 +1,8 @@
 import llm
 from PIL import Image
 from sentence_transformers import SentenceTransformer
+from transformers import AutoProcessor, AutoModel, AutoTokenizer
+import torch
 import io
 
 
@@ -33,3 +35,38 @@ class ClipEmbeddingModel(llm.EmbeddingModel):
 
         embeddings = self._model.encode(to_embed)
         return [[float(num) for num in embedding] for embedding in embeddings]
+    
+# Siglip model using huggingface transformers
+class SigLIPEmbeddingModel(llm.EmbeddingModel):
+    model_id = "siglip"
+    supports_binary = True
+    supports_text = True
+
+    def __init__(self) -> None:
+        self._model = None
+    
+    def embed_batch(self, items):
+        if self._model is None:
+            # we use the model for extracting features
+            self._model = AutoModel.from_pretrained("google/siglip-so400m-patch14-384")
+            # and processor and tokenizer for processing image and text data.
+            self._processor = AutoProcessor.from_pretrained("google/siglip-so400m-patch14-384")
+            self._tokenizer = AutoTokenizer.from_pretrained("google/siglip-so400m-patch14-384")
+        
+        images_to_embed = []
+        strings_to_embed = []
+        for item in items:
+            # strings are appended
+            if isinstance(item, str):
+                strings_to_embed.append(item)
+            elif isinstance(item, bytes):
+                images_to_embed.append(Image.open(io.BytesIO(item)))
+        t_inputs = self._tokenizer(strings_to_embed, return_tensors="pt", padding="max_length") if strings_to_embed else None
+        i_inputs = self._processor(images=images_to_embed, return_tensors="pt") if images_to_embed else None
+        with torch.no_grad():
+            outputs = []
+            outputs.append(self._model.get_text_features(**t_inputs)) if t_inputs else None
+            outputs.append(self._model.get_image_features(**i_inputs)) if i_inputs else None
+        # output format is 2D list of floats so we need to flatten it and squeeze it.
+        outputs = [torch.squeeze(output).numpy().tolist() for output in outputs if output is not None]
+        return outputs

--- a/tests/test_clip.py
+++ b/tests/test_clip.py
@@ -1,8 +1,14 @@
 import llm
 
 
-def test_run_embedding():
+def clip_test_run_embedding():
     model = llm.get_embedding_model("clip")
     result = model.embed("bunny")
     assert len(result) == 512
+    assert isinstance(result[0], float)
+
+def siglip_test_run_embedding():
+    model = llm.get_embedding_model("siglip")
+    result = model.embed("bunny")
+    assert len(result) == 1152
     assert isinstance(result[0], float)

--- a/tests/test_clip.py
+++ b/tests/test_clip.py
@@ -1,13 +1,13 @@
 import llm
 
 
-def clip_test_run_embedding():
+def test_clip_run_embedding():
     model = llm.get_embedding_model("clip")
     result = model.embed("bunny")
     assert len(result) == 512
     assert isinstance(result[0], float)
 
-def siglip_test_run_embedding():
+def test_siglip_run_embedding():
     model = llm.get_embedding_model("siglip")
     result = model.embed("bunny")
     assert len(result) == 1152


### PR DESCRIPTION
This pull request adds the [SigLIP model](https://huggingface.co/docs/transformers/main/en/model_doc/siglip#transformers.SiglipProcessor), which is a variation of the CLIP model by researchers at Google ( Xiaohua Zhai, Basil Mustafa, Alexander Kolesnikov, Lucas Beyer ). I've used the existing CLIP class as a template, and confirmed that outputs have the same shape (except for embed dimensions). 
SigLIP has 1152 dimensions.


Tests wouldn't run on my windows machine. Unrecognised by pytest.

Cases:
- No inputs: TypeError: SigLIPEmbeddingModel.embed_batch() missing 1 required positional argument: 'items''
 this is the same as the clip model class.
- Multiple inputs: Returns the embeddings as a 2d python list, with len(class_outputs) = num_of_elements_passed, and len(class_outputs[0]) = 1152.

Please let me know if any other information or tests are needed.
Thanks,